### PR TITLE
Fix span attribute existence search

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1299,8 +1299,15 @@ class BaseQueryBuilder:
             if is_tag or is_context or name in self.config.non_nullable_keys:
                 return Condition(lhs, Op(search_filter.operator), value)
             else:
-                # If not a tag, we can just check that the column is null.
-                return Condition(Function("isNull", [lhs]), Op(search_filter.operator), 1)
+                # Treat empty string queries as existence checks for attributes
+                # that may be null. Align this behaviour with tags by comparing
+                # against an empty string after wrapping the column with
+                # `ifNull` to normalize nulls to empty strings.
+                return Condition(
+                    Function("ifNull", [lhs, ""]),
+                    Op(search_filter.operator),
+                    value,
+                )
 
         is_null_condition = None
         # TODO(wmak): Skip this for all non-nullable keys not just event.type

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -443,9 +443,28 @@ def test_profile_id_column_has(params, column):
 
     assert (
         Condition(
-            Function("isNull", [Column("profile_id")]),
+            Function("ifNull", [Column("profile_id"), ""]),
             Op.NEQ,
-            1,
+            "",
+        )
+        in builder.where
+    )
+
+
+@django_db_all
+def test_missing_tag_filter(params):
+    builder = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        params,
+        query="!has:foo",
+        selected_columns=["count"],
+    )
+
+    assert (
+        Condition(
+            Function("ifNull", [Column("tags[foo]"), ""]),
+            Op.EQ,
+            "",
         )
         in builder.where
     )


### PR DESCRIPTION
## Summary
- align existence checks for attributes with tags in span search
- update profile id `has:` test
- add test covering `!has:` for tags

## Testing
- `PYENV_VERSION=3.11.12 python3 -m pytest tests/sentry/search/events/builder/test_spans_indexed.py::test_profile_id_column_has tests/sentry/search/events/builder/test_spans_indexed.py::test_missing_tag_filter -q` *(fails: No module named pytest)*
- `make test-python-ci` *(fails: No module named pytest)*
